### PR TITLE
Updated React and ReactDOM CDN to Cloudflare production version

### DIFF
--- a/templates/rocket.templ.html
+++ b/templates/rocket.templ.html
@@ -8,8 +8,8 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <!-- Babel and React via CDN -->
     <script src="https://unpkg.com/@babel/standalone@latest/babel.min.js"></script>
-    <script src="https://unpkg.com/react@18/umd/react.development.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.production.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.production.min.js"></script>
 </head>
 
 <body class="bg-[url('/static/img/gopher-2024.jpeg')] bg-cover bg-no-repeat bg-center h-screen w-screen">


### PR DESCRIPTION
This PR updates the React and ReactDOM CDN links in rocket.templ.html to use the production version from Cloudflare.

Changes

Replaced development CDN links:

<script src="https://unpkg.com/react@18/umd/react.development.js"></script>
<script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>

With:

<script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.3.1/umd/react.production.min.js"></script>
<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.3.1/umd/react-dom.production.min.js"></script>


Benefits

Enhances performance and stability.


Testing

Confirmed that the frontend works as expected after the change.


Related Issue

Fixes #28

This version is concise yet provides all necessary information. Let me know if you need further changes!
![Screenshot 2024-10-27 143840](https://github.com/user-attachments/assets/c3712dd1-e554-4449-8052-44eb34adeebc)
